### PR TITLE
Changed next() approach to iterate DataLoader

### DIFF
--- a/Chapter05.ipynb
+++ b/Chapter05.ipynb
@@ -1859,7 +1859,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "images_batch, labels_batch = iter(val_loader).next()\n",
+    "images_batch, labels_batch = next(iter(val_loader))\n",
     "logits = sbs_cnn1.predict(images_batch)"
    ]
   },
@@ -1959,7 +1959,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "images_batch, labels_batch = iter(val_loader).next()\n",
+    "images_batch, labels_batch = next(iter(val_loader))\n",
     "logits = sbs_cnn1.predict(images_batch)"
    ]
   },
@@ -2396,7 +2396,7 @@
     "\n",
     "sbs_cnn1.attach_hooks(layers_to_hook=featurizer_layers + classifier_layers)\n",
     "\n",
-    "images_batch, labels_batch = iter(val_loader).next()\n",
+    "images_batch, labels_batch = next(iter(val_loader))\n",
     "logits = sbs_cnn1.predict(images_batch)\n",
     "predicted = np.argmax(logits, 1)\n",
     "\n",

--- a/Chapter06.ipynb
+++ b/Chapter06.ipynb
@@ -354,7 +354,7 @@
    ],
    "source": [
     "torch.manual_seed(88)\n",
-    "first_images, first_labels = iter(train_loader).next()\n",
+    "first_images, first_labels = next(iter(train_loader))\n",
     "\n",
     "fig = figure2(first_images, first_labels)"
    ]


### PR DESCRIPTION
First of all, thank you for your amazing book (and repository). Lot of concepts are extremely well explained and easy to understand.

Previous chapter used `next(iter(DL))`, however, chapter 5 uses `iter(DL).next()` which throws the following error:
```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[149], line 1
----> 1 images_batch, labels_batch = iter(val_loader).next()
      2 logits = sbs_cnn1.predict(images_batch)

AttributeError: '_SingleProcessDataLoaderIter' object has no attribute 'next'
```
I don't know if that function was implemented in previous PyTorch versions, however with PyTorch 1.13, it doesn't work anymore.
> Note: Python 3.8.10, jupyterlab 3.5.0