### PR TITLE
Changed linewidth to 0.1 when binary=False

### DIFF
--- a/plots/chapter8.py
+++ b/plots/chapter8.py
@@ -136,7 +136,7 @@ def counter_vs_clock(basic_corners=None, basic_colors=None, basic_letters=None, 
             alpha = 1.0
             if draw_arrows:
                 alpha = 0.3 if ((start in targets) or (end in targets)) else 1.0
-            line = axs[is_clock].plot(*arrow_coords.T, c=color, lw=0 if draw_arrows else 2, 
+            line = axs[is_clock].plot(*arrow_coords.T, c=color, lw=0.1 if draw_arrows else 2, 
                                       alpha=alpha, linestyle='--' if alpha < 1 else '-')[0]
             if draw_arrows:
                 add_arrow(line, lw=3, alpha=alpha)

--- a/plots/chapter8.py
+++ b/plots/chapter8.py
@@ -136,8 +136,8 @@ def counter_vs_clock(basic_corners=None, basic_colors=None, basic_letters=None, 
             alpha = 1.0
             if draw_arrows:
                 alpha = 0.3 if ((start in targets) or (end in targets)) else 1.0
-            line = axs[is_clock].plot(*arrow_coords.T, c=color, lw=0.1 if draw_arrows else 2, 
-                                      alpha=alpha, linestyle='--' if alpha < 1 else '-')[0]
+            line = axs[is_clock].plot(*arrow_coords.T, c=color, lw=0 if draw_arrows else 2, 
+                                      alpha=alpha, linestyle='--' if (alpha < 1) and (not draw_arrows) else '-')[0]
             if draw_arrows:
                 add_arrow(line, lw=3, alpha=alpha)
 


### PR DESCRIPTION
The line `fig = counter_vs_clock(binary=False)` at the start of the chapter9
raises the following exception using matplotlib 3.6.2 (local jupyerlab), however
it runs fine on 3.2.2 (installed on colab):
```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/pyplot.py:119, in _draw_all_if_interactive()
    117 def _draw_all_if_interactive():
    118     if matplotlib.is_interactive():
--> 119         draw_all()

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/_pylab_helpers.py:132, in Gcf.draw_all(cls, force)
    130 for manager in cls.get_all_fig_managers():
    131     if force or manager.canvas.figure.stale:
--> 132         manager.canvas.draw_idle()

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/backend_bases.py:2054, in FigureCanvasBase.draw_idle(self, *args, **kwargs)
   2052 if not self._is_idle_drawing:
   2053     with self._idle_draw_cntx():
-> 2054         self.draw(*args, **kwargs)

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/backends/backend_agg.py:405, in FigureCanvasAgg.draw(self)
    401 # Acquire a lock on the shared font cache.
    402 with RendererAgg.lock, \
    403      (self.toolbar._wait_cursor_for_draw_cm() if self.toolbar
    404       else nullcontext()):
--> 405     self.figure.draw(self.renderer)
    406     # A GUI class may be need to update a window using this draw, so
    407     # don't forget to call the superclass.
    408     super().draw()

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/artist.py:74, in _finalize_rasterization.<locals>.draw_wrapper(artist, renderer, *args, **kwargs)
     72 @wraps(draw)
     73 def draw_wrapper(artist, renderer, *args, **kwargs):
---> 74     result = draw(artist, renderer, *args, **kwargs)
     75     if renderer._rasterizing:
     76         renderer.stop_rasterizing()

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/artist.py:51, in allow_rasterization.<locals>.draw_wrapper(artist, renderer)
     48     if artist.get_agg_filter() is not None:
     49         renderer.start_filter()
---> 51     return draw(artist, renderer)
     52 finally:
     53     if artist.get_agg_filter() is not None:

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/figure.py:3071, in Figure.draw(self, renderer)
   3068         # ValueError can occur when resizing a window.
   3070 self.patch.draw(renderer)
-> 3071 mimage._draw_list_compositing_images(
   3072     renderer, self, artists, self.suppressComposite)
   3074 for sfig in self.subfigs:
   3075     sfig.draw(renderer)

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/image.py:131, in _draw_list_compositing_images(renderer, parent, artists, suppress_composite)
    129 if not_composite or not has_images:
    130     for a in artists:
--> 131         a.draw(renderer)
    132 else:
    133     # Composite any adjacent images together
    134     image_group = []

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/artist.py:51, in allow_rasterization.<locals>.draw_wrapper(artist, renderer)
     48     if artist.get_agg_filter() is not None:
     49         renderer.start_filter()
---> 51     return draw(artist, renderer)
     52 finally:
     53     if artist.get_agg_filter() is not None:

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/axes/_base.py:3107, in _AxesBase.draw(self, renderer)
   3104         a.draw(renderer)
   3105     renderer.stop_rasterizing()
-> 3107 mimage._draw_list_compositing_images(
   3108     renderer, self, artists, self.figure.suppressComposite)
   3110 renderer.close_group('axes')
   3111 self.stale = False

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/image.py:131, in _draw_list_compositing_images(renderer, parent, artists, suppress_composite)
    129 if not_composite or not has_images:
    130     for a in artists:
--> 131         a.draw(renderer)
    132 else:
    133     # Composite any adjacent images together
    134     image_group = []

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/artist.py:51, in allow_rasterization.<locals>.draw_wrapper(artist, renderer)
     48     if artist.get_agg_filter() is not None:
     49         renderer.start_filter()
---> 51     return draw(artist, renderer)
     52 finally:
     53     if artist.get_agg_filter() is not None:

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/lines.py:799, in Line2D.draw(self, renderer)
    796 lc_rgba = mcolors.to_rgba(self._color, self._alpha)
    797 gc.set_foreground(lc_rgba, isRGBA=True)
--> 799 gc.set_dashes(*self._dash_pattern)
    800 renderer.draw_path(gc, tpath, affine.frozen())
    801 gc.restore()

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/backend_bases.py:926, in GraphicsContextBase.set_dashes(self, dash_offset, dash_list)
    923         raise ValueError(
    924             "All values in the dash list must be non-negative")
    925     if dl.size and not np.any(dl > 0.0):
--> 926         raise ValueError(
    927             'At least one value in the dash list must be positive')
    928 self._dashes = dash_offset, dash_list

ValueError: At least one value in the dash list must be positive

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/IPython/core/formatters.py:338, in BaseFormatter.__call__(self, obj)
    336     pass
    337 else:
--> 338     return printer(obj)
    339 # Finally look for special method names
    340 method = get_real_method(obj, self.print_method)

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/IPython/core/pylabtools.py:152, in print_figure(fig, fmt, bbox_inches, base64, **kwargs)
    149     from matplotlib.backend_bases import FigureCanvasBase
    150     FigureCanvasBase(fig)
--> 152 fig.canvas.print_figure(bytes_io, **kw)
    153 data = bytes_io.getvalue()
    154 if fmt == 'svg':

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/backend_bases.py:2314, in FigureCanvasBase.print_figure(self, filename, dpi, facecolor, edgecolor, orientation, format, bbox_inches, pad_inches, bbox_extra_artists, backend, **kwargs)
   2308     renderer = _get_renderer(
   2309         self.figure,
   2310         functools.partial(
   2311             print_method, orientation=orientation)
   2312     )
   2313     with getattr(renderer, "_draw_disabled", nullcontext)():
-> 2314         self.figure.draw(renderer)
   2316 if bbox_inches:
   2317     if bbox_inches == "tight":

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/artist.py:74, in _finalize_rasterization.<locals>.draw_wrapper(artist, renderer, *args, **kwargs)
     72 @wraps(draw)
     73 def draw_wrapper(artist, renderer, *args, **kwargs):
---> 74     result = draw(artist, renderer, *args, **kwargs)
     75     if renderer._rasterizing:
     76         renderer.stop_rasterizing()

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/artist.py:51, in allow_rasterization.<locals>.draw_wrapper(artist, renderer)
     48     if artist.get_agg_filter() is not None:
     49         renderer.start_filter()
---> 51     return draw(artist, renderer)
     52 finally:
     53     if artist.get_agg_filter() is not None:

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/figure.py:3071, in Figure.draw(self, renderer)
   3068         # ValueError can occur when resizing a window.
   3070 self.patch.draw(renderer)
-> 3071 mimage._draw_list_compositing_images(
   3072     renderer, self, artists, self.suppressComposite)
   3074 for sfig in self.subfigs:
   3075     sfig.draw(renderer)

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/image.py:131, in _draw_list_compositing_images(renderer, parent, artists, suppress_composite)
    129 if not_composite or not has_images:
    130     for a in artists:
--> 131         a.draw(renderer)
    132 else:
    133     # Composite any adjacent images together
    134     image_group = []

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/artist.py:51, in allow_rasterization.<locals>.draw_wrapper(artist, renderer)
     48     if artist.get_agg_filter() is not None:
     49         renderer.start_filter()
---> 51     return draw(artist, renderer)
     52 finally:
     53     if artist.get_agg_filter() is not None:

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/axes/_base.py:3107, in _AxesBase.draw(self, renderer)
   3104         a.draw(renderer)
   3105     renderer.stop_rasterizing()
-> 3107 mimage._draw_list_compositing_images(
   3108     renderer, self, artists, self.figure.suppressComposite)
   3110 renderer.close_group('axes')
   3111 self.stale = False

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/image.py:131, in _draw_list_compositing_images(renderer, parent, artists, suppress_composite)
    129 if not_composite or not has_images:
    130     for a in artists:
--> 131         a.draw(renderer)
    132 else:
    133     # Composite any adjacent images together
    134     image_group = []

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/artist.py:51, in allow_rasterization.<locals>.draw_wrapper(artist, renderer)
     48     if artist.get_agg_filter() is not None:
     49         renderer.start_filter()
---> 51     return draw(artist, renderer)
     52 finally:
     53     if artist.get_agg_filter() is not None:

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/lines.py:799, in Line2D.draw(self, renderer)
    796 lc_rgba = mcolors.to_rgba(self._color, self._alpha)
    797 gc.set_foreground(lc_rgba, isRGBA=True)
--> 799 gc.set_dashes(*self._dash_pattern)
    800 renderer.draw_path(gc, tpath, affine.frozen())
    801 gc.restore()

File ~/side_projects/brain_auth/psychopy/data_alcoholism/venv/lib/python3.8/site-packages/matplotlib/backend_bases.py:926, in GraphicsContextBase.set_dashes(self, dash_offset, dash_list)
    923         raise ValueError(
    924             "All values in the dash list must be non-negative")
    925     if dl.size and not np.any(dl > 0.0):
--> 926         raise ValueError(
    927             'At least one value in the dash list must be positive')
    928 self._dashes = dash_offset, dash_list

ValueError: At least one value in the dash list must be positive
```
Using 0.1 as line width instead of 0 (https://github.com/matplotlib/matplotlib/issues/8821/) seems to avoid the error and doesn't affect the output of the plot.